### PR TITLE
easier subclassing for core._Socket

### DIFF
--- a/gevent_zeromq/core.py
+++ b/gevent_zeromq/core.py
@@ -39,7 +39,7 @@ class _Socket(_original_Socket):
     To ensure that the ``zmq.NOBLOCK`` flag is set and that sending or recieving
     is deferred to the hub if a ``zmq.EAGAIN`` (retry) error is raised.
     
-    The `__setup_events` method is triggered when the zmq.FD for the socket is
+    The `__state_changed` method is triggered when the zmq.FD for the socket is
     marked as readable and triggers the necessary read and write events (which
     are waited for in the recv and send methods).
 

--- a/gevent_zeromq/core.pyx
+++ b/gevent_zeromq/core.pyx
@@ -41,7 +41,7 @@ cdef class _Socket(_original_Socket):
     To ensure that the ``zmq.NOBLOCK`` flag is set and that sending or recieving
     is deferred to the hub if a ``zmq.EAGAIN`` (retry) error is raised.
     
-    The `__setup_events` method is triggered when the zmq.FD for the socket is
+    The `__state_changed` method is triggered when the zmq.FD for the socket is
     marked as readable and triggers the necessary read and write events (which
     are waited for in the recv and send methods).
 


### PR DESCRIPTION
Hi Travis,

This patch changes all the methods of core._Socket to call super(_Socket,self) rather than super(Socket,self).  This lets you replace core.Socket with a custom subclass of core._Socket without hitting an infinite recursion.

  Cheers,

```
Ryan
```
